### PR TITLE
Update nodecommand.config

### DIFF
--- a/doc_source/create_deploy_nodejs_express.md
+++ b/doc_source/create_deploy_nodejs_express.md
@@ -135,8 +135,9 @@ After you have created an environment with a sample application, you can update 
 
    ```
    option_settings:
-     aws:elasticbeanstalk:container:nodejs:
-       NodeCommand: "npm start"
+     - namespace: aws:elasticbeanstalk:container:nodejs
+       option_name: NodeCommand
+       value: "npm start"
    ```
 
    For more information, see \.


### PR DESCRIPTION
*Description of changes:*
I am going through the nodejs + express elastic beanstalk tutorial (https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create_deploy_nodejs_express.html) and noticed that the instructions for nodecommand.config are out of date.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
