### PR TITLE
Updated the ruby versions supported

### DIFF
--- a/doc_source/create_deploy_Ruby.container.md
+++ b/doc_source/create_deploy_Ruby.container.md
@@ -1,6 +1,6 @@
 # Using the AWS Elastic Beanstalk Ruby Platform<a name="create_deploy_Ruby.container"></a>
 
-The AWS Elastic Beanstalk Ruby platform is a set of [environment configurations](concepts.platforms.md#concepts.platforms.ruby) for Ruby web applications that can run behind an nginx proxy server under a Puma or Passenger application server\. Each configuration corresponds to a version of Ruby, including Ruby 1\.9, Ruby 2\.0, Ruby 2\.1, Ruby 2\.2 and Ruby 2\.3\.
+The AWS Elastic Beanstalk Ruby platform is a set of [environment configurations](concepts.platforms.md#concepts.platforms.ruby) for Ruby web applications that can run behind an nginx proxy server under a Puma or Passenger application server\. Each configuration corresponds to a version of Ruby, including Ruby 1\.9, Ruby 2\.0, Ruby 2\.1, Ruby 2\.2, Ruby 2\.3, Ruby 2\.4 and Ruby 2\.5\.
 
 Elastic Beanstalk provides [configuration options](command-options.md) that you can use to customize the software that runs on the EC2 instances in your Elastic Beanstalk environment\. You can configure environment variables needed by your application and enable log rotation to Amazon S3\. The platform also predefines some common environment variables related to Rails and Rack for ease of discovery and use\.
 

--- a/doc_source/create_deploy_Ruby.container.md
+++ b/doc_source/create_deploy_Ruby.container.md
@@ -1,6 +1,6 @@
 # Using the AWS Elastic Beanstalk Ruby Platform<a name="create_deploy_Ruby.container"></a>
 
-The AWS Elastic Beanstalk Ruby platform is a set of [environment configurations](concepts.platforms.md#concepts.platforms.ruby) for Ruby web applications that can run behind an nginx proxy server under a Puma or Passenger application server\. Each configuration corresponds to a version of Ruby, including Ruby 1\.9, Ruby 2\.0, Ruby 2\.1, Ruby 2\.2, Ruby 2\.3, Ruby 2\.4 and Ruby 2\.5\.
+The AWS Elastic Beanstalk Ruby platform is a set of [environment configurations](concepts.platforms.md#concepts.platforms.ruby) for Ruby web applications that can run behind an nginx proxy server under a Puma or Passenger application server\. Each configuration corresponds to a version of Ruby.
 
 Elastic Beanstalk provides [configuration options](command-options.md) that you can use to customize the software that runs on the EC2 instances in your Elastic Beanstalk environment\. You can configure environment variables needed by your application and enable log rotation to Amazon S3\. The platform also predefines some common environment variables related to Rails and Rack for ease of discovery and use\.
 


### PR DESCRIPTION
according to `aws elasticbeanstalk list-available-solution-stacks` ruby 1.9 through 2.5 are supported now.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
