### PR TITLE
Minor concision fix to getting started guide

### DIFF
--- a/doc_source/GettingStarted.md
+++ b/doc_source/GettingStarted.md
@@ -52,7 +52,7 @@ During the environment creation process, the console tracks its progress and dis
 
 ![\[Console showing environment creation event output.\]](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/images/gettingstarted-events.png)
 
-When all of the resources finish launching and the EC2 instances running the application pass health checks, the environment's health changes to `Ok` and the website becomes ready to use\.
+When all of the resources finish launching and the EC2 instances running the application pass health checks, the environment's health changes to `Ok` and the website becomes usable\.
 
 ## Step 3: View Information about Your Environment<a name="GettingStarted.Walkthrough.ViewApp"></a>
 


### PR DESCRIPTION
'usable' versus 'ready to use.' Not sure why the Github diff tracker is showing that whole paragraph as changed when I didn't touch it, though.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
