### PR TITLE
Clarify under which user container_commands are run.

### DIFF
--- a/doc_source/customize-containers-ec2.md
+++ b/doc_source/customize-containers-ec2.md
@@ -405,7 +405,7 @@ services:
 
 You can use the `container_commands` key to execute commands that affect your application source code\. Container commands run after the application and web server have been set up and the application version archive has been extracted, but before the application version is deployed\. Non\-container commands and other customization operations are performed prior to the application source code being extracted\.
 
-Container commands are run from the staging directory, where your source code is extracted prior to being deployed to the application server\. Any changes you make to your source code in the staging directory with a container command will be included when the source is deployed to its final location\.
+The specified commands run as the root user. Container commands are run from the staging directory, where your source code is extracted prior to being deployed to the application server\. Any changes you make to your source code in the staging directory with a container command will be included when the source is deployed to its final location\.
 
 You can use `leader_only` to only run the command on a single instance, or configure a `test` to only run the command when a test command evaluates to `true`\. Leader\-only container commands are only executed during environment creation and deployments, while other commands and server customization operations are performed every time an instance is provisioned or updated\. Leader\-only container commands are not executed due to launch configuration changes, such as a change in the AMI Id or instance type\.
 


### PR DESCRIPTION
*Description of changes:* Clarified under which user container_commands are run. This piece of information is important and was missing. I copied the string from the command section to stay consistent. 

FYI I think we also should add the "The commands are processed in alphabetical order by name" sentence from the commands section to the container_commands as well but I haven't tested wether this would be true or not. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
