### PR TITLE
add -h flag to zip command for consistent output

### DIFF
--- a/doc_source/nodejs-dynamodb-tutorial.md
+++ b/doc_source/nodejs-dynamodb-tutorial.md
@@ -47,10 +47,10 @@ You can run all commands in this tutorial on a Linux virtual machine, and OS X m
 
      1. Close any running command prompts and reopen\.
 
-  1. Open a new command prompt window and run the `zip` command to verify that it works:
+  1. Open a new command prompt window and run the `zip -h` command to verify that it works:
 
      ```
-     > zip
+     > zip -h
      Copyright (C) 1990-1999 Info-ZIP
      Type 'zip "-L"' for software license.
      ...


### PR DESCRIPTION

*Issue #, if available:*
none

*Description of changes:*
add `-h` flag to `zip` command (i.e. `zip -h`) because without it, i get different output:
```
$ zip
  adding: -
zip I/O error: Invalid argument

zip error: Temporary file failure (was zipping -)
```
BTW, I am on Windows 10 64 bit using Git Bash if it matters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
