### PR TITLE
Update scheduled actions namespace for example scheduled period scale…

### DIFF
--- a/doc_source/environments-cfg-autoscaling-scheduledactions.md
+++ b/doc_source/environments-cfg-autoscaling-scheduledactions.md
@@ -114,7 +114,7 @@ This configuration file instructs Elastic Beanstalk to scale in to no running in
 
 ```
 option_settings:
-  ScheduledPeriodicScaleUp.aws:autoscaling:scheduledaction:
+  ScheduledPeriodicScaleDown.aws:autoscaling:scheduledaction:
     MinSize: '0'
     MaxSize: '1'
     DesiredCapacity: '0'


### PR DESCRIPTION
… down

Updated environments-cfg-autoscaling-scheduledactions option_setting namespace for scheduled periodic scale down events to reflect this is a scaleDown event, not ScaleUp.

*Issue #, if available:*
N/A
*Description of changes:*
The example documentation provides and example for a periodic scale down action defined as an ElasticBeanstalk option_setting to scale an environment down to 0 instances periodically.  The namespace defined in the example shows "ScaleUp" instead of "ScaleDown".


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
