### PR TITLE
The IAM policy snippet for AWSElasticBeanstalkWorkerTier is missing 'logs' actions

### DIFF
--- a/doc_source/iam-instanceprofile.md
+++ b/doc_source/iam-instanceprofile.md
@@ -64,6 +64,17 @@ Elastic Beanstalk provides three managed policies: one for the web server tier, 
         "Resource": "*"
       },
       {
+        "Sid": "CloudWatchLogsAccess",
+        "Action": [
+            "logs:PutLogEvents",
+            "logs:CreateLogStream"
+        ],
+        "Effect": "Allow",
+        "Resource": [
+            "arn:aws:logs:*:*:log-group:/aws/elasticbeanstalk*"
+        ]
+      },
+      {
         "Sid": "XRayAccess",
         "Action":[
           "xray:PutTraceSegments",


### PR DESCRIPTION
*Description of changes:*

The documentation for Managed InstanceProfile IAM Policies provides an incomplete example of what the WorkerTier policy looks like. The IAM console confirms that some 'logs' actions are also a part of the WorkerTier policy, but it's missing from the docs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
