### PR TITLE
Improve wording of `eb scale scale` flag

### DIFF
--- a/doc_source/eb3-scale.md
+++ b/doc_source/eb3-scale.md
@@ -6,9 +6,9 @@ Scales the environment to always run on a specified number of instances, setting
 
 ## Syntax<a name="eb3-scalesyntax"></a>
 
- `eb scale scale` 
+ `eb scale instance_count`
 
- `eb scale scale environment_name` 
+ `eb scale instance_count environment_name`
 
 ## Options<a name="eb3-scaleoptions"></a>
 


### PR DESCRIPTION
Using `scale` twice together in the Syntax section is confusing. The new wording clarifies that we expect an instance count number.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
