### PR TITLE
Remove unnecessary 'a' on Platform Specific Options page

### DIFF
--- a/doc_source/command-options-specific.md
+++ b/doc_source/command-options-specific.md
@@ -27,7 +27,7 @@ These configuration options do not apply to the Multicontainer Docker platform\.
 
 ## Go Platform Options<a name="command-options-golang"></a>
 
-You can use the following namespace to configure the proxy server to serve static files\. When a the proxy server receives a request for a file under the specified path, it serves the file directly instead of routing the request to your application\. This reduces the number of requests that your application has to process\.
+You can use the following namespace to configure the proxy server to serve static files\. When the proxy server receives a request for a file under the specified path, it serves the file directly instead of routing the request to your application\. This reduces the number of requests that your application has to process\.
 
 Map a path served by the proxy server to a folder in your source code that contains static assets\. Each option that you define in this namespace maps a different path\.
 
@@ -40,7 +40,7 @@ Map a path served by the proxy server to a folder in your source code that conta
 
 ## Java SE Platform Options<a name="command-options-plain-java"></a>
 
-You can use the following namespace to configure the proxy server to serve static files\. When a the proxy server receives a request for a file under the specified path, it serves the file directly instead of routing the request to your application\. This reduces the number of requests that your application has to process\.
+You can use the following namespace to configure the proxy server to serve static files\. When the proxy server receives a request for a file under the specified path, it serves the file directly instead of routing the request to your application\. This reduces the number of requests that your application has to process\.
 
 Map a path served by the proxy server to a folder in your source code that contains static assets\. Each option that you define in this namespace maps a different path\.
 
@@ -90,7 +90,7 @@ See [Environment Properties and Other Software Settings](environments-cfg-softwa
 |  GzipCompression  |  Set to `false` to disable response compression\.  |  `true`  |  `true` `false`  | 
 |  ProxyServer  |  Set the proxy to use on your environment's instances\. If you don't set this option, or if you set it to `apache`, Elastic Beanstalk uses [Apache 2\.4](https://httpd.apache.org/docs/2.4/)\. Set to `apache/2.2` if your application isn't ready to migrate away from [Apache 2\.2](https://httpd.apache.org/docs/2.2/) due to incompatible proxy configuration settings\. Set to `nginx` to use [nginx](https://www.nginx.com/)\. For more information, see [Configuring Your Tomcat Environment's Proxy Server](java-tomcat-proxy.md)\.  |  `apache`  |  `apache` `apache/2.2` `nginx`  | 
 
-You can use the following namespace to configure the proxy server to serve static files\. When a the proxy server receives a request for a file under the specified path, it serves the file directly instead of routing the request to your application\. This reduces the number of requests that your application has to process\.
+You can use the following namespace to configure the proxy server to serve static files\. When the proxy server receives a request for a file under the specified path, it serves the file directly instead of routing the request to your application\. This reduces the number of requests that your application has to process\.
 
 Map a path served by the proxy server to a folder in your source code that contains static assets\. Each option that you define in this namespace maps a different path\.
 
@@ -141,7 +141,7 @@ Run the AWS X\-Ray daemon to relay trace information from your [X\-Ray integrate
 |  GzipCompression  |  Specifies if gzip compression is enabled\. If ProxyServer is set to `none`, then gzip compression is disabled\.   |  `false`  |  `true` `false`  | 
 |  ProxyServer  |  Specifies which web server should be used to proxy connections to Node\.js\. If ProxyServer is set to `none`, then static file mappings doesn't take affect and gzip compression is disabled\.  |  `nginx`  |  `apache` `nginx` `none`  | 
 
-You can use the following namespace to configure the proxy server to serve static files\. When a the proxy server receives a request for a file under the specified path, it serves the file directly instead of routing the request to your application\. This reduces the number of requests that your application has to process\.
+You can use the following namespace to configure the proxy server to serve static files\. When the proxy server receives a request for a file under the specified path, it serves the file directly instead of routing the request to your application\. This reduces the number of requests that your application has to process\.
 
 Map a path served by the proxy server to a folder in your source code that contains static assets\. Each option that you define in this namespace maps a different path\.
 
@@ -202,7 +202,7 @@ See [Environment Properties and Other Software Settings](environments-cfg-softwa
 |  NumProcesses  |  The number of daemon processes that should be started for the process group when running WSGI applications\.  |  `1`  |  n/a  | 
 |  NumThreads  |  The number of threads to be created to handle requests in each daemon process within the process group when running WSGI applications\.  |  `15`  |  n/a  | 
 
-You can use the following namespace to configure the proxy server to serve static files\. When a the proxy server receives a request for a file under the specified path, it serves the file directly instead of routing the request to your application\. This reduces the number of requests that your application has to process\.
+You can use the following namespace to configure the proxy server to serve static files\. When the proxy server receives a request for a file under the specified path, it serves the file directly instead of routing the request to your application\. This reduces the number of requests that your application has to process\.
 
 Map a path served by the proxy server to a folder in your source code that contains static assets\. Each option that you define in this namespace maps a different path\.
 


### PR DESCRIPTION
*Description of changes:*

Fixed wording for multiple sentences on Platform Specific Options page. 

Convert 5 instances of "When a the proxy server" into "When the proxy server".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
