### PR TITLE
Add service namespace for dynamo eb worker tier

### DIFF
--- a/doc_source/iam-instanceprofile.md
+++ b/doc_source/iam-instanceprofile.md
@@ -110,7 +110,7 @@ Elastic Beanstalk provides three managed policies: one for the web server tier, 
         ],
         "Effect": "Allow",
         "Resource": [
-          "arn:aws:*:*:table/*-stack-AWSEBWorkerCronLeaderRegistry*"
+          "arn:aws:dynamodb:*:*:table/*-stack-AWSEBWorkerCronLeaderRegistry*"
         ]
       },
       {


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Uses a valid ARN for a dynamoDB table in the ElasticBeanstalk worker tier IAM instance profile policy example

Previously resulted in a `The policy failed legacy parsing (Service: AmazonIdentityManagement; Status Code: 400; Error Code: MalformedPolicyDocument;` when the `dynamodb` namespace is omitted.