### PR TITLE
Add missing quotes to files target

### DIFF
--- a/doc_source/https-storingprivatekeys.md
+++ b/doc_source/https-storingprivatekeys.md
@@ -21,7 +21,7 @@ Resources:
               DefaultValue: "aws-elasticbeanstalk-ec2-role"
 files:
   # Private key
-  /etc/pki/tls/certs/server.key:
+  "/etc/pki/tls/certs/server.key":
     mode: "000400"
     owner: root
     group: root


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Across the AWS docs, the files target is quoted however in the "Storing Private Keys Securely in Amazon S3" section this was inconsistent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
