### PR TITLE
added observation that the authentication file has to be explicitly called .dockercfg

### DIFF
--- a/doc_source/create_deploy_docker.container.console.md
+++ b/doc_source/create_deploy_docker.container.console.md
@@ -135,7 +135,7 @@ With Docker version 1\.6\.2 and earlier, the docker login command creates the au
   }
 }
 ```
-To convert a `config.json` file, remove the outer `auths` key, add an `email` key, and flatten the JSON document to match the old format\.
+To convert a `config.json` file, remove the outer `auths` key, add an `email` key, and flatten the JSON document to match the old format\. Obs: the file has to be explicitly called `.dockercfg`\.
 
 Upload the authentication file to a secure Amazon S3 bucket\. The Amazon S3 bucket must be hosted in the same region as the environment that is using it\. Elastic Beanstalk cannot download files from an Amazon S3 bucket hosted in other regions\. Grant permissions for the `s3:GetObject` operation to the IAM role in the instance profile\. For details, see [Managing Elastic Beanstalk Instance Profiles](iam-instanceprofile.md)\.
 


### PR DESCRIPTION
Added observation that the authentication file has to be explicitly called .dockercfg.

I lost some hours trying to use Beanstalk with private registry, the problem was that the S3 file I was uploading was called config.json instead of .dockercfg, I tought I could call it anything since that in the Dockerrun.aws.json file i could indicate the name of the file.