### PR TITLE
Update using-features.customenv.md

### DIFF
--- a/doc_source/using-features.customenv.md
+++ b/doc_source/using-features.customenv.md
@@ -14,7 +14,7 @@ A custom AMI also allows you to make changes to low\-level components, such as t
 
    ```
    $ aws elasticbeanstalk describe-platform-version --region us-east-2 \
-         --resource-arn "arn:aws:elasticbeanstalk:us-east-2::platform/Tomcat 8.5 with Java 8 running on 64bit Amazon Linux/3.1.6" \
+         --platform-arn "arn:aws:elasticbeanstalk:us-east-2::platform/Tomcat 8.5 with Java 8 running on 64bit Amazon Linux/3.2.1" \
          --query PlatformDescription.CustomAmiList
    [
        {
@@ -23,12 +23,12 @@ A custom AMI also allows you to make changes to low\-level components, such as t
        },
        {
            "VirtualizationType": "hvm",
-           "ImageId": "ami-020ae06fdda6a0f66"
+           "ImageId": "ami-0afc41eee457447aa"
        }
    ]
    ```
 
-1. Take note of the `ImageId` value that looks like `ami-020ae06fdda6a0f66` in the result\.
+1. Take note of the `ImageId` value that looks like `ami-0afc41eee457447aa` in the result\.
 
 The value is the stock Elastic Beanstalk AMI for the platform version, EC2 instance architecture, and AWS Region that are relevant for your application\. If you need to create AMIs for multiple platforms, architectures or AWS Regions, repeat this process to identify the correct base AMI for each combination\.
 


### PR DESCRIPTION
The describe-platform-version CLI command (https://docs.aws.amazon.com/cli/latest/reference/elasticbeanstalk/describe-platform-version.html) takes in platform-arn as an input option. However, currently in this documentation, --resource-arn has been specified as an option which is invalid and the CLI command throws the following error : 
"Unknown options: --resource-arn"

Thus, I am proposing this change.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
