### PR TITLE
Update command-options-general.md

### DIFF
--- a/doc_source/command-options-general.md
+++ b/doc_source/command-options-general.md
@@ -474,10 +474,8 @@ Configure the default listener \(port 80\) on an application load balancer or a 
 | --- | --- | --- | --- | 
 |  DefaultProcess  |  Name of the [process](#command-options-general-environmentprocess) to which to forward traffic when no rules match\.  |  `default`  |  A process name\.  | 
 |  ListenerEnabled  |  Set to `false` to disable the listener\. You can use this option to disable the default listener on port 80\.  |  `true`  |  `true` `false`  | 
-|  Protocol  |  Protocol of traffic to process\.  |  With application load balancer: `HTTP` With network load balancer: `TCP`  |  With application load balancer: `HTTP`, `HTTPS` With network load balancer: `TCP`  | 
+|  Protocol  |  Protocol of traffic to process\.  |  With application load balancer: `HTTP` With network load balancer: `TCP`  |  With application load balancer: `HTTP`, With network load balancer: `TCP`  | 
 |  Rules  |  List of [rules](#command-options-general-elbv2-listenerrule) to apply to the listener This option is only applicable to environments with an application load balancer\.  |  None  |  Comma separated list of rule names\.  | 
-|  SSLCertificateArns  |  The ARN of the SSL certificate to bind to the listener\. This option is only applicable to environments with an application load balancer\.  |  None  |  The ARN of a certificate stored in IAM or ACM\.  | 
-|  SSLPolicy  |  Specify a security policy to apply to the listener\. This option is only applicable to environments with an application load balancer\.  | None \(ELB default\) |  The name of a load balancer security policy\.  | 
 
 ## aws:elbv2:listener:listener\_port<a name="command-options-general-elbv2-listener"></a>
 


### PR DESCRIPTION
Currently, the document states that "HTTPS is a valid value for the "Protocol" field under the (aws:elbv2:listener:default) namespace. However, the default listener (port 80) works only with the HTTP Protocol. Suppose, I set the Protocol as "HTTPS" for the default listener (Port 80), on accessing the Environment's CNAME, I get the following 400 HTTP Response :

"400 Bad Request - The plain HTTP request was sent to HTTPS port"

Hence, valid values for the Protocol field should be HTTP only. Also for the default listener as HTTPS is an invalid Protocol value, the other two option names (SSLCertificateArns, SSLPolicy) needs to be removed from the (aws:elbv2:listener:default) namespace. The reason being these two option names are valid only for an HTTPS Listener.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
