### PR TITLE
Correct SourceSecurityGroupId to SourceSecurityGroupName in line 232

### DIFF
--- a/doc_source/customize-environment-resources-elasticache.md
+++ b/doc_source/customize-environment-resources-elasticache.md
@@ -229,7 +229,7 @@ Resources:
             Fn::GetOptionSetting:
               OptionName : "CachePort"
               DefaultValue: "6379"
-          SourceSecurityGroupId:
+          SourceSecurityGroupName:
             Ref: "AWSEBSecurityGroup"
   MyCacheSubnets:
     Type: "AWS::ElastiCache::SubnetGroup"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Sample CloudFormation snippet (line 232) should be "SourceSecurityGroupName" instead of "SourceSecurityGroupId".
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
