### PR TITLE
Zip should not have any sub folders

### DIFF
--- a/doc_source/dotnet-core-tutorial.md
+++ b/doc_source/dotnet-core-tutorial.md
@@ -32,7 +32,7 @@ This tutorial uses the \.NET Core SDK to generate a basic \.NET Core application
 
 1. Run the installer and follow the instructions\.
 
-This tutorial uses a command line ZIP utility to create a source bundle that you can deploy to Elastic Beanstalk\. To use the `zip` command in Windows, you can install `UnxUtils`, a lightweight collection of useful command line utilities like `zip` and `ls`\. Alternatively, you can [use Windows Explorer](applications-sourcebundle.md#using-features.deployment.source.gui) or any other ZIP utility to create source bundle archives\.
+This tutorial uses a command line ZIP utility to create a source bundle that you can deploy to Elastic Beanstalk\. To use the `zip` command in Windows, you can install `UnxUtils`, a lightweight collection of useful command line utilities like `zip` and `ls`\. Alternatively, you can [use Windows Explorer](applications-sourcebundle.md#using-features.deployment.source.gui) or any other ZIP utility to create source bundle archives\. Make sure the zip doesn't have any sub folders(inside site.zip) otherwise the deployment would fail by checking for web.config file
 
 **To install UnxUtils**
 


### PR DESCRIPTION
When using windows zip, sub folders are created which intern fail during deployment, address the issue by adding necessary comments

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
