### PR TITLE
Corrected S3 URL format

### DIFF
--- a/doc_source/https-storingprivatekeys.md
+++ b/doc_source/https-storingprivatekeys.md
@@ -26,7 +26,7 @@ files:
     owner: root
     group: root
     authentication: "S3Auth"
-    source: https://elasticbeanstalk-us-west-2-123456789012.s3-us-west-2.amazonaws.com/server.key
+    source: https://elasticbeanstalk-us-west-2-123456789012.s3.us-west-2.amazonaws.com/server.key
 ```
 
 Replace the bucket name and URL in the example with your own\. The first entry in this file adds an authentication method named `S3Auth` to the environment's Auto Scaling group's metadata\. If you have configured a custom [instance profile](concepts-roles-instance.md) for your environment, that will be used, otherwise the default value of `aws-elasticbeanstalk-ec2-role` is applied\. The default instance profile has permission to read from the Elastic Beanstalk storage bucket\. If you use a different bucket, [add permissions to the instance profile](iam-instanceprofile.md#iam-instanceprofile-addperms)\.


### PR DESCRIPTION
The S3 URL format in the example ebextension privatekey.config is incorrect.
The format should be <bucket-name>.s3.<region> and not <bucket-name>.s3-<region>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
