### PR TITLE
update dotnet core tutorial

### DIFF
--- a/doc_source/dotnet-core-tutorial.md
+++ b/doc_source/dotnet-core-tutorial.md
@@ -170,6 +170,33 @@ C:\Users\username> dotnet new web -o dotnet-core-tutorial
        }
    }
    ```
+**Note**  
+For ASP.NET Core 3.0 and 3.1, `ConfigureWebHostDefaults` calls `UseKestrel` and `UseIISIntegration`. Your Program.cs should look like this.
+ ```
+   using System;
+   using Microsoft.AspNetCore.Hosting;
+   using System.IO;
+   
+   namespace aspnetcoreapp
+   {
+       public class Program
+       {
+           public static void Main(string[] args)
+           {
+              CreateHostBuilder(args).Build().Run();
+           }
+           
+           public static IHostBuilder CreateHostBuilder(string[] args) =>
+           Host.CreateDefaultBuilder(args)
+               .ConfigureWebHostDefaults(webBuilder =>
+               {
+                   webBuilder
+                   .UseContentRoot(Directory.GetCurrentDirectory())
+                   .UseStartup<Startup>();
+               });
+       }
+   }
+   ```
 
 1. Add `Startup.cs` to run an ASP\.NET website\.  
 **Example c:\\users\\username\\dotnet\-core\-tutorial\\Startup\.cs**  
@@ -209,6 +236,8 @@ C:\Users\username> dotnet new web -o dotnet-core-tutorial
      </system.webServer>
    </configuration>
    ```
+**Note**  
+For ASP.NET Core 3.0 and 3.1, use `modules=AspNetCoreModuleV2`
 
 1. Add `dotnet-core-tutorial.csproj`, which includes IIS middleware and includes the `web.config` file from the output of `dotnet publish`\.
 **Note**  


### PR DESCRIPTION
Add code changes to make tutorial work for ASP.NET Core 3.0 and 3.1

*Issue #, if available:*

*Description of changes:*
The current tutorial works for ASP.NET Core 2.x but fails to run in ASP.NET Core 3.x . This is because `ConfigureWebHostDefaults` calls `UseKestrel` and `UseIISIntegration` internally.
`AspNetCoreModule` no longer works and fails to `publish` the app. But using `AspNetCoreModuleV2` works


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
