### PR TITLE
Fix for module not found error resulting in 502

### DIFF
--- a/doc_source/create-deploy-python-django.md
+++ b/doc_source/create-deploy-python-django.md
@@ -215,7 +215,7 @@ By default, Elastic Beanstalk looks for a file named `application.py` to start y
    ```
    option_settings:
      aws:elasticbeanstalk:container:python:
-       WSGIPath: ebdjango/wsgi.py
+       WSGIPath: ebdjango.wsgi
    ```
 
    This setting, `WSGIPath`, specifies the location of the WSGI script that Elastic Beanstalk uses to start your application\.


### PR DESCRIPTION
Using Python 3.7, Django 3.0.6, getting the following exception / 502 response with existing django.config WSGIPath: ebdjango/wsgi.py

ModuleNotFoundError: No module named 'ebdjango/wsgi'
During handling of the above exception, another exception occurred:
...
ImportError: Failed to find application, did you mean 'ebdjango/wsgi:application'?

*Issue #, if available:*

*Description of changes:* Inaccuracies in the content


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
