### PR TITLE
Correct deployment instructions to reflect Docker platform usage.

### DIFF
--- a/doc_source/create_deploy_docker_ecstutorial.md
+++ b/doc_source/create_deploy_docker_ecstutorial.md
@@ -164,7 +164,7 @@ Next, upload the source bundle to Elastic Beanstalk and create your environment\
 
 1. Open the Elastic Beanstalk console with this preconfigured link: [console\.aws\.amazon\.com/elasticbeanstalk/home\#/newApplication?applicationName=tutorials&environmentType=LoadBalanced](https://console.aws.amazon.com/elasticbeanstalk/home#/newApplication?applicationName=tutorials&environmentType=LoadBalanced)
 
-1. For **Platform**, select the platform and platform branch that match the language used by your application\.
+1. For **Platform**, select **Docker**\. For **Platform branch**, select **Multi\-container Docker running on 64bit Amazon Linux**\.
 
 1. For **Application code**, choose **Upload your code**\.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The deployment instructions reference Docker platform in free text, but then in bulleted instructions it instructs user to select their application language as the platform, which is incorrect.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
