### PR TITLE
Clarify Procfile doesn't work on Puma/Passenger platforms

### DIFF
--- a/doc_source/ruby-platform-procfile.md
+++ b/doc_source/ruby-platform-procfile.md
@@ -3,7 +3,7 @@
 To specify the command that starts your Ruby application, include a file called `Procfile` at the root of your source bundle\.
 
 **Note**  
-Elastic Beanstalk doesn't support this feature on Amazon Linux AMI Ruby platform branches \(preceding Amazon Linux 2\)\.
+Elastic Beanstalk doesn't support this feature on Amazon Linux AMI Ruby platform branches \(preceding Amazon Linux 2\)\. This includes all Platform Version variants containing "_with Puma_" and "_with Passenger_" variants, even those with modern versions of Ruby.
 
 For details about writing and using a `Procfile`, expand the *Buildfile and Procfile* section in [Extending Elastic Beanstalk Linux platforms](platforms-linux-extend.md)\.
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
I sunk several hours trying to get `Procfile` to work on the `Ruby 2.6 with Puma version 2.11.6` platform. Of course, that doesn't work because it's built on Amazon Linux and not Amazon Linux 2.

When looking at the platform versions, I thought `Amazon Linux 2018.03 v2.11.6` meant that this was later than Amazon Linux 2 (2.11.6), which is of course wrong.

I open this PR in the hopes of saving someone else wasted time in the future.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
