### PR TITLE
Added note regarding .conf file encoding requirements

### DIFF
--- a/doc_source/https-singleinstance-dotnet-linux.md
+++ b/doc_source/https-singleinstance-dotnet-linux.md
@@ -50,6 +50,9 @@ Avoid committing a configuration file that contains your private key to source c
 
 Place the following in a file with the `.conf` extension in the `.ebextensions/nginx/conf.d/` directory of your source bundle \(for example, `.ebextensions/nginx/conf.d/https.conf`\)\. Replace *app\_port* with the port number that your application listens on\. This example configures the nginx server to listen on port 443 using SSL\. For more information about these configuration files on the \.NET Core on Linux platform, see [Using the \.NET Core on Linux platform](dotnet-linux-platform.md)\.
 
+**Note**
+Make sure the \.conf files are UTF-8 encoded and NOT UTF-8-BOM.
+
 **Example \.ebextensions/nginx/conf\.d/https\.conf**  
 
 ```


### PR DESCRIPTION
nginx will constantly throw "Unknown Directive" errors if the *.conf files are formatted as UTF-8-BOM. The files work perfectly if they're formatted as plain UTF-8.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
