### PR TITLE
Update to include new location for Amazon Linux 2

### DIFF
--- a/doc_source/using-features.logging.md
+++ b/doc_source/using-features.logging.md
@@ -114,6 +114,18 @@ Elastic Beanstalk uses files in subfolders of `/opt/elasticbeanstalk/tasks` \(Li
 
   `/opt/elasticbeanstalk/tasks/publishlogs.d/`
 
+**On Amazon Linux 2:**
+
++ **Tail Logs** –
+
+  `/opt/elasticbeanstalk/config/private/logtasks/tail/`
++ **Bundle Logs** –
+
+  `/opt/elasticbeanstalk/config/private/logtasks/bundle/`
++ **Rotated Logs** –
+
+  `/opt/elasticbeanstalk/config/private/logtasks/publish/`
+
 **On Windows Server:**
 + **Tail Logs** –
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Adding a section to point out that Amazon Linux 2 logs have changed to a new location. See https://forums.aws.amazon.com/thread.jspa?messageID=956696&#956696.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
