### PR TITLE
Fix Procfile examples for .NET Core

### DIFF
--- a/doc_source/dotnet-linux-procfile.md
+++ b/doc_source/dotnet-linux-procfile.md
@@ -9,8 +9,8 @@ The following example uses a `Procfile` to specify two applications for Elastic 
 **Example Procfile**  
 
 ```
-web: ./dotnet-core-app1/dotnetcoreapp1.dll
-web2: ./dotnet-core-app2/dotnetcoreapp2.dll
+web: dotnet ./dotnet-core-app1/dotnetcoreapp1.dll
+web2: dotnet ./dotnet-core-app2/dotnetcoreapp2.dll
 ```
 
 For details about writing and using a `Procfile`, expand the *Buildfile and Procfile* section in [Extending Elastic Beanstalk Linux platforms](platforms-linux-extend.md)\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Just having `web: ./dotnet-core-app1/dotnetcoreapp1.dll` in your Procfile doesn't actually work. You need to add the `dotnet` command for it to work. I found this out after spending about an hour debugging Elastic Beanstalk deployment failures.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
