### PR TITLE
Update platforms-linux-extend.md

### DIFF
--- a/doc_source/platforms-linux-extend.md
+++ b/doc_source/platforms-linux-extend.md
@@ -28,7 +28,7 @@ All paths in the `Buildfile` are relative to the root of the source bundle\. In 
 make: ./build.sh
 ```
 
-If you want to provide custom build steps, we recommend that you use `predeploy` platform hooks for anything but the simplest commands, instead of a `Buildfile`\. Platform hooks allow richer scripts and better error handling\. Platform hooks are described in the previous section\.
+If you want to provide custom build steps, we recommend that you use `predeploy` platform hooks for anything but the simplest commands, instead of a `Buildfile`\. Platform hooks allow richer scripts and better error handling\. Platform hooks are described in the next section\.
 
 ### Procfile<a name="platforms-linux-extend.proc"></a>
 


### PR DESCRIPTION
*Description of changes:*

Maybe after a reordering the sections got switched around, but platform hooks are after the Buildfile/Procfile section.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
