### PR TITLE
Update environments-create-awscli.md

### DIFF
--- a/doc_source/environments-create-awscli.md
+++ b/doc_source/environments-create-awscli.md
@@ -15,7 +15,11 @@
    ```
    $ aws elasticbeanstalk describe-application-versions --application-name my-app --version-label v1
    ```
+   If it doesn't, create it with\:
 
+   ```
+   $ aws elasticbeanstalk create-application --application-name my-app
+   ```
    If you don't have an application version for your source yet, create it\. For example, the following command creates an application version from a source bundle in Amazon Simple Storage Service \(Amazon S3\)\.
 
    ```


### PR DESCRIPTION
Without the create-application, the user will face:

An error occurred (InvalidParameterValue) when calling the CreateApplicationVersion operation: No Application named 'my-app' found.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
