### PR TITLE
Update create-deploy-python-django.md

### DIFF
--- a/doc_source/create-deploy-python-django.md
+++ b/doc_source/create-deploy-python-django.md
@@ -213,9 +213,9 @@ By default, Elastic Beanstalk looks for a file named `application.py` to start y
 **Example \~/ebdjango/\.ebextensions/django\.config**  
 
    ```
-   option_settings:
-     aws:elasticbeanstalk:container:python:
-       WSGIPath: ebdjango.wsgi:application
+    option_settings:
+        aws:elasticbeanstalk:container:python:
+            WSGIPath: ebdjango/wsgi.py
    ```
 
    This setting, `WSGIPath`, specifies the location of the WSGI script that Elastic Beanstalk uses to start your application\.


### PR DESCRIPTION
If customers are following the tutorial they will run into "2020-10-19 16:18:15    ERROR   Your WSGIPath refers to a file that does not exist." And they would be right because the tree of the project is:

ebdjango
├── __init__.py
├── __pycache__
│   ├── __init__.cpython-38.pyc
│   ├── settings.cpython-38.pyc
│   ├── urls.cpython-38.pyc
│   └── wsgi.cpython-38.pyc
├── settings.py
├── urls.py
└── wsgi.py

The suggestion made "ebdjango/wsgi.py" fix it.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
