### PR TITLE
Note that Procfile should not include UTF-8 BOM marker

### DIFF
--- a/doc_source/dotnet-linux-procfile.md
+++ b/doc_source/dotnet-linux-procfile.md
@@ -6,6 +6,11 @@ We recommend that you always provide a `Procfile` in the source bundle with your
 
 The following example uses a `Procfile` to specify two applications for Elastic Beanstalk to run on the same web server\.
 
+**Note**  
+Procfile contents should be UTF-8 encoded, without a UTF-8 BOM header
+
+The accidental inclusion of a BOM header (likely inserted if using Visual Studio) can lead to `There is no proc command in proc file` deployment errors as the file is not correctly parsed.
+
 **Example Procfile**  
 
 ```


### PR DESCRIPTION
*Description of changes:*
I'm suggesting a change to the documentation to indicate that if the `Procfile` (at least, untested others) is encoded as `UTF-8 with BOM marker` (byte order mark) the file is unrecognized by EB during deployment, with this error:

```
[ERROR] There is no proc command in proc file. Aborting the deployment.
```

This led to some confusion, as the file definitely existed and matched what the documentation provided as an example. Unfortunately, Visual Studio (Windows) for me included a BOM marker in the initial save for the `Procfile` leading to this issue.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
