### PR TITLE
Point starting page to current branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The open source version of the AWS Elastic Beanstalk Developer Guide. You can submit feedback and requests for changes by submitting issues in this repo or by making proposed changes and submitting a pull request.
 
-The starting page of this guide is [What Is AWS Elastic Beanstalk?](https://github.com/awsdocs/aws-elastic-beanstalk-developer-guide/blob/master/doc_source/Welcome.md).
+The starting page of this guide is [What Is AWS Elastic Beanstalk?](doc_source/Welcome.md).
 
 ## License Summary
 


### PR DESCRIPTION
Instead of hardcoding the branch name (used to be master but now it's main) use a relative path

---


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
