### PR TITLE
Fix documenting default load balancer to Classic

### DIFF
--- a/doc_source/using-features.managing.elb.md
+++ b/doc_source/using-features.managing.elb.md
@@ -18,7 +18,7 @@ Elastic Beanstalk supports all three load balancer types\. The following table s
 |  Application Load Balancer  |   ✓ Yes  |   ✓ Yes  | 
 |  Network Load Balancer  |   ✓ Yes  |   ☓ No  | 
 
-By default, Elastic Beanstalk creates an Application Load Balancer for your environment when you enable load balancing with the Elastic Beanstalk console or the EB CLI\. It configures the load balancer to listen for HTTP traffic on port 80 and forward this traffic to instances on the same port\. You can choose the type of load balancer that your environment uses only during environment creation\. Later, you can change settings to manage the behavior of your running environment's load balancer, but you can't change its type\.
+By default, Elastic Beanstalk creates a Classic Load Balancer for your environment when you enable load balancing with the Elastic Beanstalk console or the EB CLI\. It configures the load balancer to listen for HTTP traffic on port 80 and forward this traffic to instances on the same port\. You can choose the type of load balancer that your environment uses only during environment creation\. Later, you can change settings to manage the behavior of your running environment's load balancer, but you can't change its type\.
 
 **Note**  
 Your environment must be in a VPC with subnets in at least two Availability Zones to create an Application Load Balancer\. All new AWS accounts include default VPCs that meet this requirement\. If your environment is in a VPC with subnets in only one Availability Zone, it defaults to a Classic Load Balancer\. If you don't have any subnets, you can't enable load balancing\.


### PR DESCRIPTION
**Description of changes**
It seems there's a mismatch in the documentation as to what default load balancer is used on environment creation. [This line in the documentation (see image) says by default a Classic Load Balancer is used](https://github.com/awsdocs/aws-elastic-beanstalk-developer-guide/blame/main/doc_source/command-options-general.md#L251), and indeed when I created an EB environment via the EB CLI it defaulted to a Classic Load Balancer. This conflicts with the line in this PR that says the default is an Application Load Balancer. I don't think that is correct so I've submitted this PR to document it uses a Classic Load Balancer by default. 

<img width="949" alt="Screen Shot 2021-06-05 at 11 11 40 PM" src="https://user-images.githubusercontent.com/27811981/120889877-65f3e500-c653-11eb-8ee2-36e26d413036.png">

I may be misunderstanding something (perhaps creating via AWS Console will use ALB but EB CLI will default to Classic?), but I figured that if I'm misunderstanding then maybe this needs a little more clarification?

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. 
- [x] I've read the contributing guidelines
