### PR TITLE
Update migration example in create-deploy-python-django.md

### DIFF
--- a/doc_source/create-deploy-python-django.md
+++ b/doc_source/create-deploy-python-django.md
@@ -450,14 +450,14 @@ You can add commands to your `.ebextensions` script that are run when your site 
    ```
    container_commands:
      01_migrate:
-       command: "django-admin.py migrate"
-       leader_only: true
+      command: "source /var/app/venv/*/bin/activate && python3 manage.py migrate"
+      leader_only: true
    option_settings:
      aws:elasticbeanstalk:application:environment:
        DJANGO_SETTINGS_MODULE: ebdjango.settings
    ```
 
-   This configuration file runs the `django-admin.py migrate` command during the deployment process, before starting your application\. Because it runs before the application starts, you must also configure the `DJANGO_SETTINGS_MODULE` environment variable explicitly \(usually `wsgi.py` takes care of this for you during startup\)\. Specifying `leader_only: true` in the command ensures that it is run only once when you're deploying to multiple instances\.
+   This configuration file activates the server's virtual environment and runs the `manage.py migrate` command during the deployment process, before starting your application\. Because it runs before the application starts, you must also configure the `DJANGO_SETTINGS_MODULE` environment variable explicitly \(usually `wsgi.py` takes care of this for you during startup\)\. Specifying `leader_only: true` in the command ensures that it is run only once when you're deploying to multiple instances\.
 
 1. Deploy your application\.
 


### PR DESCRIPTION
Update the container command example to activate a venv and migrate changes to the database on deployment. Previous command was based on Amazon Linux 1, this command works better on Linux 2.

 See this Stackoverflow question for additional info and discussion: https://stackoverflow.com/questions/62457165/deploying-django-to-elastic-beanstalk-migrations-failed

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
