### PR TITLE
Update reference to Python 3.7

### DIFF
--- a/doc_source/create-deploy-python-flask.md
+++ b/doc_source/create-deploy-python-flask.md
@@ -21,7 +21,7 @@ this is output
 
 On Linux and macOS, use your preferred shell and package manager\. On Windows 10, you can [install the Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to get a Windows\-integrated version of Ubuntu and Bash\.
 
-Flask requires Python 2\.7 or 3\.4 or newer\. In this tutorial we use Python 3\.6 and the corresponding Elastic Beanstalk platform version\. Install Python by following the instructions at [Setting up your Python development environment](python-development-environment.md)\.
+Flask requires Python 2\.7 or 3\.4 or newer\. In this tutorial we use Python 3\.7 and the corresponding Elastic Beanstalk platform version\. Install Python by following the instructions at [Setting up your Python development environment](python-development-environment.md)\.
 
 The [Flask](http://flask.pocoo.org/) framework will be installed as part of the tutorial\.
 
@@ -179,11 +179,11 @@ Next, you'll create your application environment and deploy your configured appl
 1. Initialize your EB CLI repository with the eb init command:
 
    ```
-   ~/eb-flask$ eb init -p python-3.6 flask-tutorial --region us-east-2
+   ~/eb-flask$ eb init -p python-3.7 flask-tutorial --region us-east-2
    Application flask-tutorial has been created.
    ```
 
-   This command creates a new application named `flask-tutorial` and configures your local repository to create environments with the latest Python 3\.6 platform version\.
+   This command creates a new application named `flask-tutorial` and configures your local repository to create environments with the latest Python 3\.7 platform version\.
 
 1. \(optional\) Run eb init again to configure a default keypair so that you can connect to the EC2 instance running your application with SSH:
 


### PR DESCRIPTION
*Description of changes:*

Updated the Python guide to create a Flask application using Python 3.7 instead of 3.6 as 3.6 is now a deprecated platform.  Although users can still use Python 3.6, a warning is displayed when creating an application with this platform.  When using Python 3.7, this warning is not given as the platform is supported.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
