### PR TITLE
remove eb cli scripts link as it's not functional

### DIFF
--- a/doc_source/eb-cli3-install.md
+++ b/doc_source/eb-cli3-install.md
@@ -3,7 +3,6 @@
 The AWS Elastic Beanstalk Command Line Interface \(EB CLI\) is a command line client that you can use to create, configure, and manage Elastic Beanstalk environments\. For more information about the EB CLI, see [Using the Elastic Beanstalk command line interface \(EB CLI\)](eb-cli3.md)\.
 
 **Topics**
-+ [Install the EB CLI using setup scripts](#eb-cli3-install.scripts)
 + [Manually install the EB CLI](eb-cli3-install-advanced.md)
 
 ## Install the EB CLI using setup scripts<a name="eb-cli3-install.scripts"></a>


### PR DESCRIPTION
the link did not worked and I did not manage to find a "setup scripts" page

There is probably a better way to do this but this fix seems fastest.

*Issue #, if available:*
Link does not work.

*Description of changes:*
Removed it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
Yup