### PR TITLE
Fix out-dated Dockerfile for Building custom img

### DIFF
--- a/doc_source/single-container-docker-configuration.md
+++ b/doc_source/single-container-docker-configuration.md
@@ -147,14 +147,14 @@ Create a `Dockerfile` when you don't already have an existing image hosted in a 
 The following snippet is an example of the `Dockerfile`\. When you follow the instructions in [Using the Docker platform](single-container-docker.md), you can upload this `Dockerfile` as written\. Elastic Beanstalk runs the game 2048 when you use this `Dockerfile`\.
 
 ```
-FROM ubuntu:12.04
+FROM ubuntu:20.04
 
 RUN apt-get update
 RUN apt-get install -y nginx zip curl
 
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf
-RUN curl -o /usr/share/nginx/www/master.zip -L https://codeload.github.com/gabrielecirulli/2048/zip/master
-RUN cd /usr/share/nginx/www/ && unzip master.zip && mv 2048-master/* . && rm -rf 2048-master master.zip
+RUN curl -o /var/www/html/master.zip -L https://github.com/gabrielecirulli/2048/archive/refs/heads/master.zip
+RUN cd /var/www/html/ && unzip master.zip && mv 2048-master/* . && rm -rf 2048-master master.zip
 
 EXPOSE 80
 


### PR DESCRIPTION
*Issue #, if available:*
Current example dockerfile uses invalid external links with out-dated base image version.

*Description of changes:*
Use current stable version for base image and fixed download link with same content.
Fix nginx source file location for current nginx install.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
