### PR TITLE
Documentation has the wrong log filenames

### DIFF
--- a/doc_source/platforms-linux-extend.md
+++ b/doc_source/platforms-linux-extend.md
@@ -56,7 +56,7 @@ foo: bin/fooapp
 
 Elastic Beanstalk configures the proxy server to forward requests to your main web application on port 5000, and you can configure this port number\. A common use for a `Procfile` is to pass this port number to your application as a command argument\. For details about proxy configuration, expand the *Reverse proxy configuration* section on this page\.
 
-Elastic Beanstalk captures standard output and error streams from `Procfile` processes in log files\. Elastic Beanstalk names the log files after the process and stores them in `/var/log`\. For example, the `web` process in the preceding example generates logs named `web-1.log` and `web-1.error.log` for `stdout` and `stderr`, respectively\.
+Elastic Beanstalk captures standard output and error streams from `Procfile` processes in log files\. Elastic Beanstalk names the log files after the process and stores them in `/var/log`\. For example, the `web` process in the preceding example generates a log file named `web.stdout.log`\.
 
 ## Platform hooks<a name="platforms-linux-extend.hooks"></a>
 


### PR DESCRIPTION
The log files are not named as the documentation suggests, at least in the Go platform for AL2.
Assuming with have the following `Procfile`:
```
web: /some/app
web2: /some/other-app
```
 As your can see below instead of `web-1.log/web-1.error.log` there are these two files:
```
[ec2-user@ip-172-31-37-89 ~]$ ls -lha /var/log/web*
-rw------- 1 root root 537 Jan 29 22:25 /var/log/web2.stdout.log
-rw------- 1 root root 368 Jan 29 22:25 /var/log/web.stdout.log
```
These seem to include also error output from the processes so I don't think there is an `*.error.log` file.

Anyway the documentation is wrong.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
