### PR TITLE
Correcting the 01login.sh script syntax

### DIFF
--- a/doc_source/single-container-docker-configuration.md
+++ b/doc_source/single-container-docker-configuration.md
@@ -74,7 +74,7 @@ You need to set up AWS Systems Manager to complete these steps\. For more inform
    ```
    ### example 01login.sh
    #!/bin/bash
-   USER=/opt/elasticbeanstalk/bin/get-config environment -k USER
+   USER=`/opt/elasticbeanstalk/bin/get-config environment -k USER`
    PASSWD=/opt/elasticbeanstalk/bin/get-config environment -k PASSWD
    docker login -u $USER -p $PASSWD
    ```


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

The output of "/opt/elasticbeanstalk/bin/get-config environment -k USER" needs to be stored in the USER variable. Hence, the command should be wrapped in back ticks (`) and not double-quotes (") in order for it to be evaluated, and not stored as a literal string. 

The current example results in the following error,
2022/12/17 17:08:46.781350 [ERROR] An error occurred during execution of command [app-deploy] - [RunAppDeployPreBuildHooks]. Stop running the command. Error: Command .platform/hooks/prebuild/01login.sh failed with error exit status 125. Stderr:unknown shorthand flag: 'k' in -k

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
